### PR TITLE
add release tasks to gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ This repository is designed to be built with Gradle. The best IDE experience is 
 Intellij.
 
 This repository can be built as is. On the right menu bar in Intellij, there is a 
-Gradle menu. Toggle Tasks > build and double-click on build to run the build.
-This will create a build artifacts in the `build` folder. The built jar can be found
+Gradle menu. Toggle Run Configurations, and double click each configuration to run it. 
+- `clean` deletes the `build` folder
+- `build` will create build artifacts in the `build` folder. The built jar can be found
 in `build/libs`. 
+- `javadoc` creates documentation in `build/docs`
+- `releaseProcessingLib` creates the release artifacts in the `release` folder
 
 
 ## Project Diary

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,22 @@
+import java.util.Properties
+
 plugins {
     id("java")
+    id("java-library")
 }
 
-group = "library.template"
+// the short name of your library. This string will name relevant files and folders.
+val libName = "HelloLibrary"
+// Such as:
+// <libName>.jar will be the name of your build jar
+// <libName>.zip will be the name of your release file
+group = "com.example"
 version = "1.0-SNAPSHOT"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 repositories {
@@ -15,17 +25,113 @@ repositories {
     maven { url = uri("https://jogamp.org/deployment/maven/") }
 }
 
+val processingCore by configurations.creating
+
 dependencies {
-    implementation("com.github.micycle1:processing-core-4:4.3.1")
+    // resolve Processing core
+    compileOnly("com.github.micycle1:processing-core-4:4.3.1")
+    
+    // external dependency TODO actually use dependency in library
+    implementation("org.apache.commons:commons-math3:3.6.1")
 
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
 tasks.jar {
-    archiveFileName.set("template.jar")
+    archiveBaseName.set(libName)
+    archiveClassifier.set("")
+    archiveVersion.set("")
 }
 
 tasks.test {
     useJUnitPlatform()
+}
+
+//======================
+// For releasing library
+
+val libraryProperties = Properties().apply {
+    load(rootProject.file("library.properties").inputStream())
+}
+
+val userHome = System.getProperty("user.home")
+val libVersion = libraryProperties.getProperty("version")
+
+val releaseRoot = "$rootDir/release"
+val releaseName = libName
+val releaseDirectory = "$releaseRoot/$releaseName"
+
+tasks.register("releaseProcessingLib") {
+    dependsOn("clean", "build", "javadoc", "jar")
+    finalizedBy("packageRelease")
+
+    doFirst {
+        println("Releasing library $libName")
+        println(org.gradle.internal.jvm.Jvm.current())
+
+        println("Cleaning release...")
+        project.delete(files(
+            "$releaseDirectory",
+            "$releaseRoot/$releaseName.zip",
+            "$releaseRoot/$releaseName.txt"
+        ))
+    }
+
+    doLast {
+        println("Creating package...")
+
+        println("Copy library...")
+        copy {
+            from(layout.buildDirectory.file("libs/${libName}.jar"))
+            into("$releaseDirectory/library")
+        }
+
+        println("Copy dependencies...")
+        copy {
+            from(configurations.runtimeClasspath)
+            into("$releaseDirectory/library")
+        }
+
+        println("Copy assets...")
+        copy {
+            from("$rootDir")
+            include("shaders/**", "native/**")
+
+            into("$releaseDirectory/library")
+            exclude("*.DS_Store")
+        }
+
+        println("Copy javadoc...")
+        copy {
+            from(layout.buildDirectory.dir("docs/javadoc"))
+            into("$releaseDirectory/reference")
+        }
+
+        println("Copy additional artifacts...")
+        copy {
+            from(rootDir)
+            include("README.md", "readme/**", "library.properties", "examples/**", "src/**")
+
+            into(releaseDirectory)
+            exclude("*.DS_Store", "**/networks/**")
+        }
+
+        println("Copy repository library.text...")
+        copy {
+            from(rootDir)
+            include("library.properties")
+            into(releaseRoot)
+            rename("library.properties", "$libName.txt")
+        }
+    }
+}
+
+tasks.register<Zip>("packageRelease") {
+    dependsOn("releaseProcessingLib")
+    archiveFileName.set("${libName}.zip")
+    from(releaseDirectory)
+    into(libName)
+    destinationDirectory.set(file(releaseRoot))
+    exclude("**/*.DS_Store")
 }

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,57 @@
+# More on this file here: https://github.com/processing/processing/wiki/Library-Basics
+# UTF-8 supported.
+
+# The name of your Library as you want it formatted.
+name=Hello Library
+
+# List of authors. Links can be provided using the syntax [author name](url).
+authors=[Your Name](https://your.website.com)
+
+# A web page for your Library, NOT a direct link to where to download it.
+url=https://example.com/library-template
+
+# The category (or categories) of your Library, must be from the following list:
+#   "3D"            "Animation"     "Compilations"      "Data"          
+#   "Fabrication"   "Geometry"      "GUI"               "Hardware"      
+#   "I/O"           "Language"      "Math"              "Simulation"    
+#   "Sound"         "Utilities"     "Typography"        "Video & Vision"
+# 
+# If a value other than those listed is used, your Library will listed as 
+# "Other". Many categories must be comma-separated.
+categories=Other
+
+# A short sentence (or fragment) to summarize the Library's function. This will 
+# be shown from inside the PDE when the Library is being installed. Avoid 
+# repeating the name of your Library here. Also, avoid saying anything redundant 
+# like mentioning that it's a Library. This should start with a capitalized 
+# letter, and end with a period.
+sentence=
+
+# Additional information suitable for the Processing website. The value of
+# 'sentence' always will be prepended, so you should start by writing the
+# second sentence here. If your Library only works on certain operating systems,
+# mention it here.
+paragraph=
+
+# Links in the 'sentence' and 'paragraph' attributes can be inserted using the
+# same syntax as for authors. 
+# That is, [here is a link to Processing](http://processing.org/)
+
+# A version number that increments once with each release. This is used to 
+# compare different versions of the same Library, and check if an update is 
+# available. You should think of it as a counter, counting the total number of 
+# releases you've had. NOTE: This must be parsable as an int!
+version=1
+
+# The version as the user will see it. If blank, the version attribute will be 
+# used here. This should be a single word, with no spaces. This is treated as a String
+prettyVersion=
+
+# The min and max revision of Processing compatible with your Library.
+# Note that these fields use the revision and not the version of Processing, 
+# parsable as an int. For example, the revision number for 4.2 is 1292. 
+# You can find the revision numbers in the change log: https://raw.githubusercontent.com/processing/processing/master/build/shared/revisions.txt
+# Only use maxRevision (or minRevision), when your Library is known to 
+# break in a later (or earlier) release. Otherwise, use the default value 0.
+minRevision=0
+maxRevision=0

--- a/src/main/java/com/example/HelloLibrary.java
+++ b/src/main/java/com/example/HelloLibrary.java
@@ -1,4 +1,4 @@
-package library.template;
+package com.example;
 
 import processing.core.*;
 


### PR DESCRIPTION
This adds a subset of the tasks in the processing template for releasing the library.

This differs in that it doesn't create the library.properties file from variables, and has no support for Processing libraries.

This also refactors the naming of the library, to hopefully be clearer as to what a group is, the package name, and the library name.