### PR TITLE
docs: fix description of where library appears in processing

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -84,8 +84,8 @@ those sections for [resolving dependencies](#resolving-dependencies).
     2. have Processing library dependencies
    
     This variable is in the editable section, in case the location determined is incorrect. A 
-    symptom of an incorrect `sketchbookLocation` is that your library does not show up in the
-    Contribution Manager in Processing, after being installed. Please look at our 
+    symptom of an incorrect `sketchbookLocation` is that your library does not show up as a
+    contributed library Processing, after being installed. Please look at our 
     [troubleshooting guide](troubleshooting.md) if you suspect this is the case.
  
 ## Creating examples

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,10 +27,9 @@ Now that your environment is set up, follow these steps to get familiar with the
    `deployToProcessingSketchbook`, and double click on `deployToProcessingSketchbook`. 
    - This will build the library, create the release artifacts, and copy them to the folder 
    where Processing libraries are stored.
-3. **Check if the library appears in the Contribution Manager:** 
-   - Open Processing, and click on `Sketch` > `Import Library ...` > `Manage Libraries ...`. 
-   This opens the Contribution Manager. 
-   - You should see an entry named "A Template Example Library" with a check mark next to it. 
+3. **Check if the library appears as a contributed library:** 
+   - Open Processing, and click on `Sketch` > `Import Library ...`.
+   - You should see an entry named "A Template Example Library" in the menu as `Contributed`. 
    This is the sample library you just installed using the template. 
    - If it does not appear, please check the [troubleshooting guide](troubleshooting.md).
 4. **Customize the library information**:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-## Library does not appear in the Contribution Manager
+## Library does not appear as contributed library in Processing
 
 1. Please check that the value you have for your library name in the code is the same as the `libName` in
    the `build.gradle.kts` file. 


### PR DESCRIPTION
fix to issue #60 
new library will show as a contributed library in menu for all platforms, not in Contributions Manager (this is only for linux)