### PR TITLE
use release tag name for prettyVersion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+      - 'test*'
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           gradle-version: 8.5
       - name: Build with Gradle
         id: build
-        run: gradle buildReleaseArtifacts
+        run: gradle -Pversion=${{ github.event.release.tag_name }} buildReleaseArtifacts
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - release-version-in-txt
     tags:
       - 'v*'
       - 'test*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - release-version-in-txt
     tags:
       - 'v*'
-      - 'test*'
 
 jobs:
   release:
@@ -28,7 +27,7 @@ jobs:
           gradle-version: 8.5
       - name: Build with Gradle
         id: build
-        run: gradle -Pversion=${{ github.event.release.tag_name }} buildReleaseArtifacts
+        run: gradle -Pversion=v-tag-manual buildReleaseArtifacts
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/docs/release.md
+++ b/docs/release.md
@@ -40,7 +40,10 @@ Releasing your library on GitHub allows users to access known-working versions o
 5. Add a title and description for the release, highlighting key updates or changes.
 6. Click on **Publish release**. 
 
-This will trigger the GitHub workflow (`.github/workflows/release.yml`), which automatically create release artifacts—`*.txt`, `*.zip`, `*.pdex` files—and add them to the release.
+This will trigger the GitHub workflow (`.github/workflows/release.yml`), which automatically create release artifacts—`*.txt`, `*.zip`, `*.pdex` files—and add them to the release. 
+
+!!! Important
+    The release tag created on Github will be propagated to the release artifacts, specifically the `prettyVersion` in the txt file and `library.properties` file in the zip. This overwrites the value input for `version` in the `build.gradle.kts` file.
 
 !!! Note
     By default, GitHub will also include compressed versions of your source code (e.g., `Source code (zip)` and `Source code (tar.gz)`).


### PR DESCRIPTION
In github action for releasing artifacts, pass release tag as parameter to gradle task that builds artifacts. This should replace the version in the build.gradle.kts file with the release tag.