### PR TITLE
fixed deployToProcessingSketchbook 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -256,6 +256,10 @@ tasks.register("deployToProcessingSketchbook") {
     group = "processing"
     dependsOn("buildReleaseArtifacts")
 
+    doFirst {
+        println("Copy to sketchbook  $sketchbookLocation ...")
+    }
+
     doLast {
         val installDirectory = file("$sketchbookLocation/libraries/$libName")
 
@@ -263,16 +267,15 @@ tasks.register("deployToProcessingSketchbook") {
         delete(installDirectory)
 
         println("Copying fresh build to sketchbook $sketchbookLocation ...")
-        project.copy {
-            from(releaseDirectory) {
-                include(
-                    "library.properties",
-                    "examples/**",
-                    "library/**",
-                    "reference/**",
-                    "src/**"
-                )
-            }
+        copy {
+            from(releaseDirectory)
+            include(
+                "library.properties",
+                "examples/**",
+                "library/**",
+                "reference/**",
+                "src/**"
+            )
             into(installDirectory)
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -256,18 +256,26 @@ tasks.register("deployToProcessingSketchbook") {
     group = "processing"
     dependsOn("buildReleaseArtifacts")
 
-    doFirst {
-        println("Copy to sketchbook  $sketchbookLocation ...")
-    }
-    val installDirectory = "$sketchbookLocation/libraries/$libName"
-    copy {
-        from(releaseDirectory)
-        include("library.properties",
-            "examples/**",
-            "library/**",
-            "reference/**",
-            "src/**"
-        )
-        into(installDirectory)
+    doLast {
+        val installDirectory = file("$sketchbookLocation/libraries/$libName")
+
+        println("Removing old install from: $installDirectory")
+        delete(installDirectory)
+
+        println("Copying fresh build to sketchbook $sketchbookLocation ...")
+        project.copy {
+            from(releaseDirectory) {
+                include(
+                    "library.properties",
+                    "examples/**",
+                    "library/**",
+                    "reference/**",
+                    "src/**"
+                )
+            }
+            into(installDirectory)
+            duplicatesStrategy = DuplicatesStrategy.INCLUDE
+        }
+       
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -274,8 +274,6 @@ tasks.register("deployToProcessingSketchbook") {
                 )
             }
             into(installDirectory)
-            duplicatesStrategy = DuplicatesStrategy.INCLUDE
         }
-       
     }
 }


### PR DESCRIPTION
The copy action did not run properly. We had to run deployToProcessingSketchbook twice in order to copy the files properly to the local libraries folder.

Fixes #74 (Edit by @SableRaf)