### PR TITLE
fix doc errors

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -105,16 +105,16 @@ already run Gradle tasks, and edited the `release.properties` file.
     library, toggle `Tasks` > `processing` and double click `writeLibraryProperties`. This task will
     copy all the values in `release.properties`, and also include the `version` in your `build.gradle.kts`
     file as `prettyVersion`.
-2.  **To build the library and create the release artifacts, run the Gradle task `releaseProcessingLib`.**
+2.  **To build the library and create the release artifacts, run the Gradle task `buildReleaseArtifacts`.**
     This task will create a `release` folder with needed artifacts. To do this, go to the Gradle menu 
-    (elephant), toggle `Tasks` > `processing` and double click `releaseProcessingLib`. This task 
+    (elephant), toggle `Tasks` > `processing` and double click `buildReleaseArtifacts`. This task 
     has bundled the following required tasks:
     1.  `build` task: this bundles a number of build tasks, including the `jar` task which creates a
         jar file. all build artifacts are in the folder `build`.
     2.  documentation build.
     3.  creation of the `library.properties` file: this file is built from the properties set in the
        `release.properties` file, plus the version, in the task `writeLibraryProperties`.
-    4.  within the `releaseProcessingLib` task, the `release` folder is created, jars of the library and
+    4.  within the `buildReleaseArtifacts` task, the `release` folder is created, jars of the library and
         dependencies are copied, and the `library.properties` file is copied. Also, a zip file is made.
 3.  When you would like to test your library in Processing, toggle `Tasks` > `processing` and double click
     `deployToProcessingSketchbook`, which will create the release artifacts, and copy them into the 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,5 @@
 # Getting Started
-We're excited that you're interested in contributing to the Processing ecosystem! Building a library lets you expand Processing’s capabilities and it's a great way to give back by sharing your custom tools with the community.
+We're excited that you're interested in contributing to the Processing ecosystem! Building a library lets you expand Processing’s capabilities, and it's a great way to give back by sharing your custom tools with the community.
 
 This guide will help you set up your development environment and start building your library using the provided template.
 
@@ -7,7 +7,7 @@ This guide will help you set up your development environment and start building 
 ## Setting up the environment
 Follow these steps to create your own repository on GitHub and install the necessary tools.
 
-1. **Create a new Github repository** using the [processing-library-template](https://github.com/processing/processing-library-template)
+1. **Create a new GitHub repository** using the [processing-library-template](https://github.com/processing/processing-library-template)
    as a base.
    (See: [How to create a repository from a template.](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template))
    Choose a name that reflects the library you're building. Make sure to read about Processing's [naming rules for libraries](https://github.com/benfry/processing4/wiki/Library-Basics#library-naming-rules). You can always rename the repository later.
@@ -21,21 +21,18 @@ Follow these steps to create your own repository on GitHub and install the neces
 ## Testing the Library Template
 Now that your environment is set up, follow these steps to get familiar with the template and make sure everything works correctly:
 
-1. **Open up your new repository in your chosen IDE.**
-2. **Run the Gradle task `deployToProcessingSketchbook`:** 
-   - In the Gradle menu (the elephant icon) in your IDE, navigate to `Tasks` > `processing` > 
-   `deployToProcessingSketchbook`, and double click on `deployToProcessingSketchbook`. 
-   - This will build the library, create the release artifacts, and copy them to the folder 
-   where Processing libraries are stored.
-3. **Check if the library appears as a contributed library:** 
-   - Open Processing, and click on `Sketch` > `Import Library ...`.
-   - You should see an entry named "A Template Example Library" in the menu as `Contributed`. 
-   This is the sample library you just installed using the template. 
-   - If it does not appear, please check the [troubleshooting guide](troubleshooting.md).
-4. **Customize the library information**:
-   - Open the file `release.properties` and edit the `name`, `authors`, and `sentence` fields to match your library. 
-   - Rerun the `deployToProcessingSketchbook` Gradle task to update the library information.
-   - Open the Contribution Manager again to see your changes. The name, description, and author(s) should be updated.
+1.  **Open up your new repository in your chosen IDE.**
+2.  **Run the Gradle task `deployToProcessingSketchbook`:** 
+    *In the Gradle menu (the elephant icon) in your IDE, navigate to `Tasks` > `processing` > 
+    `deployToProcessingSketchbook`, and double-click on `deployToProcessingSketchbook`. 
+    * This will build the library, create the release artifacts, and copy them to the folder 
+    where Processing libraries are stored.
+3.  **Check if the library appears as a contributed library:** 
+    * Open Processing, and click on `Sketch` > `Import Library ...`.
+    * You should see an entry named "A Template Example Library" in the menu as `Contributed`. 
+    This is the sample library you just installed using the template. 
+    * If it does not appear, please check the [troubleshooting guide](troubleshooting.md).
+
 
 ## Next Steps
 Great, now that you're familiar with the library template, you can explore additional guides:


### PR DESCRIPTION
- rename in docs reference to legacy `releaseProcessingLib` with reference to current task `buildReleaseArtifacts`
- fix nested lists formatting
- remove last step in getting started, since it is no longer relevant

fixes some of the issues raised in issue #73 