### PR TITLE
add toolchain resolver

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}


### PR DESCRIPTION
The toolchain resolver is needed to download java versions the user doesn't already have, particularly for VSCode.
I didn't need this resolver, perhaps because Intellij has it's own resolver.